### PR TITLE
Setting to control number of additional items displayed

### DIFF
--- a/app/client/views/hosts/host_list.js
+++ b/app/client/views/hosts/host_list.js
@@ -44,8 +44,9 @@ Template.hostList.events({
   },
 
   'click #load-more': function () {
-    var previousLimit = Session.get('hostViewLimit') || 25
-    var newLimit = previousLimit + 25
+    var viewIncrement = Session.get('viewIncrement') || 25
+    var previousLimit = Session.get('hostViewLimit') || viewIncrement
+    var newLimit = previousLimit + viewIncrement
     Session.set('hostViewLimit', newLimit)
   },
 

--- a/app/client/views/hosts/host_service_list.js
+++ b/app/client/views/hosts/host_service_list.js
@@ -59,8 +59,9 @@ Template.hostServiceList.events({
   },
 
   'click #load-more': function () {
-    var previousLimit = Session.get('hostServiceViewLimit') || 25
-    var newLimit = previousLimit + 25
+    var viewIncrement = Session.get('viewIncrement') || 25
+    var previousLimit = Session.get('hostServiceViewLimit') || viewIncrement
+    var newLimit = previousLimit + viewIncrement
     Session.set('hostServiceViewLimit', newLimit)
   },
 

--- a/app/client/views/issues/issue_list.js
+++ b/app/client/views/issues/issue_list.js
@@ -46,9 +46,10 @@ Template.issueList.events({
   },
 
   'click #load-more': function () {
-    var previouslimit = Session.get('issueViewLimit') || 25
-    var newlimit = previouslimit + 25
-    Session.set('issueViewLimit', newlimit)
+    var viewIncrement = Session.get('viewIncrement') || 25
+    var previousLimit = Session.get('issueViewLimit') || viewIncrement
+    var newLimit = previousLimit + viewIncrement
+    Session.set('issueViewLimit', newLimit)
   },
 
   'click #load-all': function () {

--- a/app/client/views/settings/settings.html
+++ b/app/client/views/settings/settings.html
@@ -36,7 +36,7 @@
               {{#if numViewItems.value}}
                 <input type="text"  class="u-full-width" name="num-items" placeholder="{{numViewItems.value}}">
               {{else}}
-                <input type="text"  class="u-full-width" name="num-items" placeholder="22">
+                <input type="text"  class="u-full-width" name="num-items" placeholder="25">
               {{/if}}
             </div>
             <div class="two columns">

--- a/app/client/views/settings/settings.html
+++ b/app/client/views/settings/settings.html
@@ -24,6 +24,28 @@
         {{/if}}
       </div>
     </div>
+    <hr />
+    <div class="row">
+      <div class="six columns">
+        <h5>View</h5>
+        <p>Number of hosts/services/etc. to show per page</p>
+        
+        <form id="set-view-increment">
+          <div class="row">
+            <div class="four columns">
+              {{#if numViewItems.value}}
+                <input type="text"  class="u-full-width" name="num-items" placeholder="{{numViewItems.value}}">
+              {{else}}
+                <input type="text"  class="u-full-width" name="num-items" placeholder="22">
+              {{/if}}
+            </div>
+            <div class="two columns">
+              <button class="button button-primary">Save</button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
   </div>
 </div>
 </template>

--- a/app/client/views/settings/settings.js
+++ b/app/client/views/settings/settings.js
@@ -6,5 +6,25 @@ Template.settings.events({
   },
   'click #toggle-persist-view-filters': function () {
     return Meteor.call('togglePersistViewFilters')
+  },
+  'submit #set-view-increment': function (event, tpl) {
+    event.preventDefault()
+    var num_items = tpl.find('[name=num-items]').value
+    Meteor.call('setViewIncrement', num_items, function (err) {
+      if (err) {
+        Alerts.insert({
+          class: 'alert-error',
+          strong: 'Error',
+          message: err.reason
+        })
+        return
+      }
+      Alerts.insert({
+        class: 'alert-success',
+        strong: 'Success',
+        message: 'Number of view items changed'
+      })
+
+    })
   }
 })

--- a/app/lib/methods/matchers.js
+++ b/app/lib/methods/matchers.js
@@ -49,5 +49,10 @@ Matchers = { // eslint-disable-line
   isResponseCode: Match.Where(function (x) {
     check(x, String)
     return x.match(/^[1|2|3|4|5]\d{2}$/)
+  }),
+
+  isPositiveInteger: Match.Where(function (x) {
+    check(x, Match.Integer)
+    return x > 0
   })
 }

--- a/app/lib/methods/settings.js
+++ b/app/lib/methods/settings.js
@@ -6,7 +6,8 @@ Meteor.methods({
   changeLairUserPassword: changeLairUserPassword,
   toggleLairUserIsAdmin: toggleLairUserIsAdmin,
   toggleClientSideUpdates: toggleClientSideUpdates,
-  togglePersistViewFilters: togglePersistViewFilters
+  togglePersistViewFilters: togglePersistViewFilters,
+  setViewIncrement: setViewIncrement
 })
 
 function createLairUser (email, password, isAdmin) {
@@ -120,4 +121,13 @@ function togglePersistViewFilters () {
   } else {
     return Settings.update({setting: 'persistViewFilters'}, {$set: {enabled: false}})
   }
+}
+
+function setViewIncrement (numItems) {
+  if (!Meteor.user().isAdmin) {
+    throw new Meteor.Error(403, 'Access Denied')
+  }
+  numItems = parseInt(numItems, 10)
+  check(numItems, Matchers.isPositiveInteger)
+  return Settings.upsert({setting: 'numViewItems'}, {$set: {value: numItems}})
 }

--- a/app/lib/router/hosts.js
+++ b/app/lib/router/hosts.js
@@ -5,7 +5,7 @@ Router.route('/projects/:id/hosts', {
   controller: 'ProjectController',
   onRun: function () {
     if (Settings.findOne({
-      settings: 'persistViewFilters',
+      setting: 'persistViewFilters',
       enabled: true
     })) {
       this.next()
@@ -137,7 +137,7 @@ Router.route('/projects/:id/hosts/:hid/services', {
   controller: 'ProjectController',
   onRun: function () {
     if (Settings.findOne({
-      settings: 'persistViewFilters',
+      setting: 'persistViewFilters',
       enabled: true
     })) {
       this.next()
@@ -324,7 +324,7 @@ Router.route('/projects/:id/hosts/:hid/issues', {
   controller: 'ProjectController',
   onRun: function () {
     if (Settings.findOne({
-      settings: 'persistViewFilters',
+      setting: 'persistViewFilters',
       enabled: true
     })) {
       this.next()

--- a/app/lib/router/hosts.js
+++ b/app/lib/router/hosts.js
@@ -11,6 +11,7 @@ Router.route('/projects/:id/hosts', {
       this.next()
       return
     }
+    Session.set('viewIncrement', 25)
     Session.set('hostViewLimit', 25)
     Session.set('hostListSearch', null)
     Session.set('hostListStatusButtongrey', null)
@@ -22,6 +23,19 @@ Router.route('/projects/:id/hosts', {
     this.next()
   },
   data: function () {
+    // Handle updating of the number of items to view by default
+    var numViewItems = 25
+    var numViewItemsSetting = Settings.findOne({setting: 'numViewItems'})
+    if (numViewItemsSetting) {
+      numViewItems = numViewItemsSetting.value
+    }
+    if ( Session.get('hostViewLimit') == Session.get('viewIncrement')) {
+      Session.set('hostViewLimit', numViewItems)
+    } else if (Session.get('hostViewLimit') < numViewItems) {
+      Session.set('hostViewLimit', numViewItems)
+    }
+    Session.set('viewIncrement', numViewItems)
+
     var project = Projects.findOne({
       _id: this.params.id
     })
@@ -46,7 +60,7 @@ Router.route('/projects/:id/hosts', {
         }
       },
       hosts: function () {
-        var limit = Session.get('hostViewLimit') || 25
+        var limit = Session.get('hostViewLimit') || Session.get('viewIncrement') || 25
         var query = {
           projectId: self.params.id,
           status: {
@@ -129,6 +143,7 @@ Router.route('/projects/:id/hosts/:hid/services', {
       this.next()
       return
     }
+    Session.set('viewIncrement', 25)
     Session.set('hostServiceViewLimit', 25)
     Session.set('hostServiceListSearch', null)
     Session.set('hostServiceListStatusButtongrey', null)
@@ -140,6 +155,19 @@ Router.route('/projects/:id/hosts/:hid/services', {
     this.next()
   },
   data: function () {
+    // Handle updating of the number of items to view by default
+    var numViewItems = 25
+    var numViewItemsSetting = Settings.findOne({setting: 'numViewItems'})
+    if (numViewItemsSetting) {
+      numViewItems = numViewItemsSetting.value
+    }
+    if ( Session.get('hostServiceViewLimit') == Session.get('viewIncrement')) {
+      Session.set('hostServiceViewLimit', numViewItems)
+    } else if (Session.get('hostServiceViewLimit') < numViewItems) {
+      Session.set('hostServiceViewLimit', numViewItems)
+    }
+    Session.set('viewIncrement', numViewItems)
+
     var project = Projects.findOne({
       _id: this.params.id
     })
@@ -174,7 +202,7 @@ Router.route('/projects/:id/hosts/:hid/services', {
         }
       },
       services: function () {
-        var limit = Session.get('hostServiceViewLimit') || 25
+        var limit = Session.get('hostServiceViewLimit') || Session.get('viewIncrement') || 25
         var query = {
           projectId: self.params.id,
           hostId: self.params.hid,

--- a/app/lib/router/issues.js
+++ b/app/lib/router/issues.js
@@ -5,7 +5,7 @@ Router.route('/projects/:id/issues', {
   controller: 'ProjectController',
   onRun: function () {
     if (Settings.findOne({
-      settings: 'persistViewFilters',
+      setting: 'persistViewFilters',
       enabled: true
     })) {
       this.next()

--- a/app/lib/router/issues.js
+++ b/app/lib/router/issues.js
@@ -11,7 +11,8 @@ Router.route('/projects/:id/issues', {
       this.next()
       return
     }
-    Session.set('issueViewLimit', 50)
+    Session.set('viewIncrement', 25)
+    Session.set('issueViewLimit', 25)
     Session.set('issueListSearch', null)
     Session.set('issueListStatusButtongrey', null)
     Session.set('issueListStatusButtonblue', null)
@@ -22,6 +23,19 @@ Router.route('/projects/:id/issues', {
     this.next()
   },
   data: function () {
+    // Handle updating of the number of items to view by default
+    var numViewItems = 25
+    var numViewItemsSetting = Settings.findOne({setting: 'numViewItems'})
+    if (numViewItemsSetting) {
+      numViewItems = numViewItemsSetting.value
+    }
+    if ( Session.get('issueViewLimit') == Session.get('viewIncrement')) {
+      Session.set('issueViewLimit', numViewItems)
+    } else if (Session.get('issueViewLimit') < numViewItems) {
+      Session.set('issueViewLimit', numViewItems)
+    }
+    Session.set('viewIncrement', numViewItems)
+
     var project = Projects.findOne({
       _id: this.params.id
     })
@@ -46,7 +60,7 @@ Router.route('/projects/:id/issues', {
         }
       },
       issues: function () {
-        var limit = Session.get('issueViewLimit') || 50
+        var limit = Session.get('issueViewLimit') || 25
         var query = {
           projectId: self.params.id,
           status: {

--- a/app/lib/router/services.js
+++ b/app/lib/router/services.js
@@ -31,7 +31,7 @@ Router.route('/projects/:id/hosts/:hid/services/:sid/issues', {
   controller: 'ProjectController',
   onRun: function () {
     if (Settings.findOne({
-      settings: 'persistViewFilters',
+      setting: 'persistViewFilters',
       enabled: true
     })) {
       this.next()

--- a/app/lib/router/settings.js
+++ b/app/lib/router/settings.js
@@ -11,6 +11,9 @@ Router.route('/settings', {
       persistViewFilters: Settings.findOne({
         setting: 'persistViewFilters'
       }),
+      numViewItems: Settings.findOne({
+        setting: 'numViewItems'
+      }),
       isSettings: true
     }
   }


### PR DESCRIPTION
Fixed a small mistake preventing persistViewFilters from functioning.

Added a new setting that controls the number of items that are displayed for hosts/host services/issues both initially and when Show More is clicked.