### PR TITLE
Added Target Blank

### DIFF
--- a/app/client/views/hosts/host_hostname_list.html
+++ b/app/client/views/hosts/host_hostname_list.html
@@ -32,7 +32,7 @@
       <div class="seven columns">
         <ul class="list-unstyled">
         {{#each links}}
-          <li><a href="{{this}}">{{this}}</a></li>
+          <li><a href="{{this}}" target="_blank">{{this}}</a></li>
         {{/each}}
         </ul>
       </div>


### PR DESCRIPTION
Adding target="_blank" to a hyper link will make it open in a new tab.
I think it's a good idea to open each hostname in a new tab instead of
opening it in the current tab making you leave lair.