### PR TITLE
Package versions fix for heroku

### DIFF
--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -51,7 +51,7 @@ logging@1.1.17
 meteor@1.6.1
 meteor-base@1.0.4
 minifier-css@1.2.16
-minifier-js@2.0.0
+minifier-js@1.2.18
 minimongo@1.0.21
 mobile-experience@1.0.4
 mobile-status-bar@1.0.14
@@ -87,7 +87,7 @@ spacebars@1.0.15
 spacebars-compiler@1.1.2
 srp@1.0.10
 standard-minifier-css@1.3.4
-standard-minifier-js@2.0.0
+standard-minifier-js@1.2.1
 templating@1.3.2
 templating-compiler@1.3.2
 templating-runtime@1.3.2


### PR DESCRIPTION
Heroku failed to build meteor package due to version contraints on the `standart-minifier-js@2.0.0`, so it has been downgraded to 1.2.1.

Also the build log showed that `minifier-js` was automatically downgraded to 1.2.18, so I decided to downgrade it manually.