### PR TITLE
Sort Projects By Name

### DIFF
--- a/app/lib/router/netblocks.js
+++ b/app/lib/router/netblocks.js
@@ -18,7 +18,7 @@ Router.route('/projects/:id/netblocks', {
     return {
       projectId: self.params.id,
       projectName: project.name,
-      netblocks: Netblocks.find({}).fetch(),
+      netblocks: Netblocks.find({}, {sort: {cidr: 1}}).fetch(),
       netblock: Netblocks.findOne({
         _id: Session.get('netblocksSelected')
       })

--- a/app/lib/router/projects.js
+++ b/app/lib/router/projects.js
@@ -16,7 +16,7 @@ Router.route('/projects', {
     ]
   },
   data: function () {
-    return Projects.find({}).fetch()
+    return Projects.find({}, {sort: {createdAt: 1}}).fetch()
   }
 })
 

--- a/app/lib/router/projects.js
+++ b/app/lib/router/projects.js
@@ -16,7 +16,7 @@ Router.route('/projects', {
     ]
   },
   data: function () {
-    return Projects.find({}, {sort: {createdAt: 1}}).fetch()
+    return Projects.find({}, {sort: {name: 1}}).fetch()
   }
 })
 


### PR DESCRIPTION
Sorting projects by name, creation date is another good option but doesn't appear to have timestamp so projects created on the same day would still shuffle.